### PR TITLE
COMP: Add switch default for point component type

### DIFF
--- a/src/itkMZ3MeshIO.cxx
+++ b/src/itkMZ3MeshIO.cxx
@@ -513,6 +513,10 @@ MZ3MeshIO::WritePoints(void * buffer)
       WritePoints(static_cast<long double *>(buffer));
       break;
     }
+    default:
+    {
+      itkExceptionMacro("Unsupported point component type");
+    }
   }
 }
 


### PR DESCRIPTION
To address macos-14 CI build warning:

src/itkMZ3MeshIO.cxx:484:11: warning: 11 enumeration values not handled in switch: 'UNKNOWNCOMPONENTTYPE', 'UCHAR', 'CHAR'... [-Wswitch]
